### PR TITLE
feat: try mount Chromium system configuration directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,10 @@
             sha256 = "sha256-GGltZ0/6rGQJixlGz3Na/vAwOlTeUR87WGyAPpLmtKM=";
           };
 
+          extraBwrapArgs = [
+            "--ro-bind-try /etc/chromium /etc/chromium"
+          ];
+
           extraInstallCommands =
             let
               contents = pkgs.appimageTools.extract { inherit pname version src; };


### PR DESCRIPTION
Chromium system directory `/etc/chromium` should be mounted in bwrap environment, if available. This ensures that policies, especially the ones generated by NixOS `programs.chromium.extraOpts` and `programs.chromium.extensions`, are correctly read and adopted by Helium.