### PR TITLE
fix: make VaapiVideoEncoder opt-in again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,6 @@
               enableFeatures
               ++ pkgs.lib.optionals libvaSupport [
                 "VaapiVideoDecoder"
-                "VaapiVideoEncoder"
               ];
 
             extraPkgs = pkgs: pkgs.lib.optionals libvaSupport [ pkgs.libva ];


### PR DESCRIPTION
`VaapiVideoEncoder` may break some sites (e.g., Teams screen sharing) when enabled globally via `libvaSupport`. Revert to making it an opt-in feature exposed through `enableFeatures`, so accelerated encoding is only active when the user explicitly requests it.